### PR TITLE
Removing stale space before links

### DIFF
--- a/theorems.typ
+++ b/theorems.typ
@@ -235,13 +235,18 @@
     if it.citation.supplement != none {
       supplement = it.citation.supplement
     }
+    let supplement_spaced = if (supplement == none or supplement == "") {
+      ""
+    } else {
+      [#supplement~]
+    }
 
     let loc = it.element.location()
     let thms = query(selector(<meta:thmenvcounter>).after(loc), loc)
     let number = thmcounters.at(thms.first().location()).at("latest")
     return link(
       it.target,
-      [#supplement~#numbering(it.element.numbering, ..number)]
+      [#supplement_spaced#numbering(it.element.numbering, ..number)]
     )
   }
 

--- a/theorems.typ
+++ b/theorems.typ
@@ -235,7 +235,7 @@
     if it.citation.supplement != none {
       supplement = it.citation.supplement
     }
-    let supplement_spaced = if (supplement == none or supplement == "") {
+    let supplement_spaced = if (supplement == none or supplement == [] or (supplement.has("text") and supplement.text == "")) {
       ""
     } else {
       [#supplement~]


### PR DESCRIPTION
Actually, this is relevant with languages with different nouns cases, e.g. in russian. In those languages it's quite senseless to have fixed supplements before theorem links since each time a new case should be used.

Also, I'm quite new to typst and I might miss something important or maybe I just did something stupid, so please check if it's ok.

This works for me at least hehe...

---

One other thing: I compare supplement with `""`, but somehow it doesn't work, idk why. 
