### PR TITLE
Allow the block in thmbox to be breakable

### DIFF
--- a/theorems.typ
+++ b/theorems.typ
@@ -131,7 +131,7 @@
         width: 100%,
         inset: 1.2em,
         radius: 0.3em,
-        breakable: false,
+        breakable: true,
         ..blockargs.named(),
         ..blockargs_individual.named(),
         [#title#name#separator#body]


### PR DESCRIPTION
If we allow thmbox to be breakable, text flow is improved and also allows making very long theorems that span across multiple pages.

## Comparison
| Unbreakable :x: | Breakable 👍🏼 |
|--------|--------|
| ![image](https://github.com/sahasatvik/typst-theorems/assets/77280741/9870d510-e1f2-4dea-94f9-41e42696ff3e) | ![image](https://github.com/sahasatvik/typst-theorems/assets/77280741/4bdf4b9d-bef3-40d0-8b22-d749cc471a28) |

It would be cool if Typst also fixed the rounded corners such that you can tell if a block has finished or not, but I think that would be pretty hard to implement.