### PR TITLE
Fix ref for manually numbered theorems

### DIFF
--- a/theorems.typ
+++ b/theorems.typ
@@ -228,7 +228,7 @@
       outlined: false,
       caption: name,
       supplement: supplement,
-      numbering: numbering,
+      numbering: if number == auto and numbering != none { numbering } else { (..nums) => number },
     )
   }
 }


### PR DESCRIPTION
This fixes references to manually numbered theorems.
