### PR TITLE
Update ctheorems for Typst 0.12

### DIFF
--- a/basic.typ
+++ b/basic.typ
@@ -2,7 +2,7 @@
 #show: thmrules.with(qed-symbol: $square$)
 
 #set page(width: 16cm, height: auto, margin: 1.5cm)
-#set text(font: "Linux Libertine", lang: "en")
+#set text(font: "Libertinus Serif", lang: "en")
 #set heading(numbering: "1.1.")
 
 #let theorem = thmbox("theorem", "Theorem", fill: rgb("#eeffee"))

--- a/differential_calculus.typ
+++ b/differential_calculus.typ
@@ -60,7 +60,7 @@
 
 #let project(title: "", authors: (), body) = {
   set document(author: authors, title: title)
-  set text(font: "Linux Libertine", lang: "en")
+  set text(font: "Libertinus Serif", lang: "en")
   set heading(numbering: "1.1.", )
   set par(justify: true)
 

--- a/manual_template.typ
+++ b/manual_template.typ
@@ -1,7 +1,7 @@
 #let project(title: "", authors: (), url: "", body) = {
   set page(paper: "a4", numbering: "1", number-align: center)
   set document(author: authors, title: title)
-  set text(font: "Linux Libertine", lang: "en")
+  set text(font: "Libertinus Serif", lang: "en")
   set heading(numbering: "1.1.")
   set par(justify: true)
   set list(marker: ([•], [--]))

--- a/theorems.typ
+++ b/theorems.typ
@@ -222,6 +222,7 @@
 
 #let thmrules(qed-symbol: $qed$, doc) = {
 
+  show figure.where(kind: "thmenv"): set block(breakable: true)
   show figure.where(kind: "thmenv"): set align(start)
   show figure.where(kind: "thmenv"): it => it.body
 

--- a/theorems.typ
+++ b/theorems.typ
@@ -163,7 +163,7 @@
 #let thm-qed-done = state("thm-qed-done", false)
 
 // The configured QED symbol
-#let thm-qed-symbol = state("thm-qed-symbol", "a")
+#let thm-qed-symbol = state("thm-qed-symbol", $qed$)
 
 // Show the qed symbol, update state
 #let thm-qed-show = {

--- a/theorems.typ
+++ b/theorems.typ
@@ -34,11 +34,12 @@
       number = none
     }
     if number == auto and numbering != none {
-      result = locate(loc => {
+      result = context {
+        let heading-counter = counter(heading).get()
         return thmcounters.update(thmpair => {
           let counters = thmpair.at("counters")
           // Manually update heading counter
-          counters.at("heading") = counter(heading).at(loc)
+          counters.at("heading") = heading-counter
           if not identifier in counters.keys() {
             counters.insert(identifier, (0, ))
           }
@@ -74,11 +75,11 @@
             "latest": latest
           )
         })
-      })
+      }
 
-      number = thmcounters.display(x => {
-        return global_numbering(numbering, ..x.at("latest"))
-      })
+      number = context {
+        global_numbering(numbering, ..thmcounters.get().at("latest"))
+      }
     }
 
     return figure(
@@ -161,10 +162,13 @@
 // Track whether the qed symbol has already been placed in a proof
 #let thm-qed-done = state("thm-qed-done", false)
 
+// The configured QED symbol
+#let thm-qed-symbol = state("thm-qed-symbol", "a")
+
 // Show the qed symbol, update state
 #let thm-qed-show = {
-  thm-qed-done.update("thm-qed-symbol")
-  thm-qed-done.display()
+  thm-qed-done.update(true)
+  context [#thm-qed-symbol.get()]
 }
 
 // If placed in a block equation/enum/list, place a qed symbol to its right
@@ -200,12 +204,12 @@
 #let proof-bodyfmt(body) = {
   thm-qed-done.update(false)
   body
-  locate(loc => {
-    if thm-qed-done.at(loc) == false {
+  context {
+    if thm-qed-done.at(here()) == false {
       h(1fr)
       thm-qed-show
     }
-  })
+  }
 }
 
 #let thmproof(..args) = thmplain(
@@ -218,6 +222,7 @@
 
 #let thmrules(qed-symbol: $qed$, doc) = {
 
+  show figure.where(kind: "thmenv"): set align(start)
   show figure.where(kind: "thmenv"): it => it.body
 
   show ref: it => {
@@ -237,7 +242,7 @@
     }
 
     let loc = it.element.location()
-    let thms = query(selector(<meta:thmenvcounter>).after(loc), loc)
+    let thms = query(selector(<meta:thmenvcounter>).after(loc))
     let number = thmcounters.at(thms.first().location()).at("latest")
     return link(
       it.target,
@@ -272,7 +277,7 @@
     it
   }
 
-  show "thm-qed-symbol": qed-symbol
+  thm-qed-symbol.update(qed-symbol)
 
   doc
 }


### PR DESCRIPTION
Hi,

This PR makes the necessary changes for ctheorems to work correctly in Typst 0.12, including:

1. Fixing alignment of theorems after https://github.com/typst/typst/pull/4276
2. Fixing breakability of theorem figures (for the same reason)
3. Replacing deprecated introspection primitives with `context { }`
4. Adding a state for the QED symbol parameter, replacing the outdated state.display() (and the current combination of that with a text show rule is a quite unorthodox way to do it)
5. Ensuring the new default font is used in example files (Linux Libertine -> Libertinus Serif)

I'm aware there's a branch with larger changes incoming, but this should be enough to cut a new release for ctheorems and keep Typst 0.12 users happy until those changes land. :slightly_smiling_face:

Closes #34
Related: https://github.com/sahasatvik/typst-theorems/issues/36, https://github.com/sahasatvik/typst-theorems/issues/38