### PR TITLE
Remove explicit breaking: false

### DIFF
--- a/theorems.typ
+++ b/theorems.typ
@@ -132,7 +132,6 @@
         width: 100%,
         inset: 1.2em,
         radius: 0.3em,
-        breakable: false,
         ..blockargs.named(),
         ..blockargs_individual.named(),
         [#title#name#separator#body]


### PR DESCRIPTION
(To my understanding... Quite new to Typst)

The removed lines overrides any show rules set for breaking, and should be passed from `..blockargs.named()` instead of explicitly. Otherwise from my testing, `thmplain()` is also non-breakable.